### PR TITLE
Updated EPM API

### DIFF
--- a/epm-client/src/main/java/io/elastest/epm/client/service/EpmService.java
+++ b/epm-client/src/main/java/io/elastest/epm/client/service/EpmService.java
@@ -29,6 +29,7 @@ import io.elastest.epm.client.api.PackageApi;
 import io.elastest.epm.client.api.PoPApi;
 import io.elastest.epm.client.api.WorkerApi;
 import io.elastest.epm.client.model.Key;
+import io.elastest.epm.client.model.KeyValuePair;
 import io.elastest.epm.client.model.PoP;
 import io.elastest.epm.client.model.RemoteEnvironment;
 import io.elastest.epm.client.model.ResourceGroup;
@@ -149,8 +150,11 @@ public class EpmService {
         RemoteEnvironment re = new RemoteEnvironment();
         ResourceGroup resourceGroup = null;
         Worker worker = null;
+        PoP openstackPoP = null;
 
         try {
+            // Register a OpenStack PoP
+            openstackPoP = registerOpenstackPop();
             // Providing a new remote VM
             resourceGroup = sendPackage(packageFilePath, "m1tub.tar",
                     sharedFolder + "/tmp" + "/ansible");
@@ -278,6 +282,27 @@ public class EpmService {
                     "Exception when calling PackageApi#receivePackage");
             e.printStackTrace();
         }
+    }
+
+    public PoP registerOpenstackPop() {
+        PoP pop = new PoP();
+        pop.setName("tub-os");
+        pop.setInterfaceEndpoint("http://cpu06.codeurjc.es:5000/v2.0");
+        pop.addInterfaceInfoItem(new KeyValuePair().key("auth_url").value("http://cpu06.codeurjc.es:5000/v2.0"));
+        pop.addInterfaceInfoItem(new KeyValuePair().key("password").value("Eil3rac8soojoam"));
+        pop.addInterfaceInfoItem(new KeyValuePair().key("project_name").value("tub"));
+        pop.addInterfaceInfoItem(new KeyValuePair().key("username").value("tub"));
+
+        PoP result = null;
+        try {
+            result = popApi.registerPoP(pop);
+        } catch (ApiException e) {
+            System.err
+                    .println("Exception when calling PoPApi#registerPoP");
+            e.printStackTrace();
+        }
+
+        return result;
     }
 
     public Worker registerWorker(ResourceGroup rg) throws ServiceException {

--- a/epm-client/src/main/resources/epm_packages/ansible/metadata.yaml
+++ b/epm-client/src/main/resources/epm_packages/ansible/metadata.yaml
@@ -1,2 +1,2 @@
 name: example-name
-type: ansible
+type: openstack

--- a/epm-client/src/main/resources/epm_packages/ansible/play.yaml
+++ b/epm-client/src/main/resources/epm_packages/ansible/play.yaml
@@ -3,11 +3,6 @@
   tasks:
     - name: Creating VM
       os_server:
-        auth:
-          auth_url: "http://cpu06.codeurjc.es:5000/v2.0"
-          password: Eil3rac8soojoam
-          project_name: tub
-          username: tub
         flavor: m1.tub
         auto_floating_ip: yes
         image: "Ubuntu Xenial"


### PR DESCRIPTION
This is an example of how you might set up the TORM to use the latest EPM API. 

Important changes:
1) The EPM ansible adapter now supports also AWS plays (example here: https://github.com/mpauls/epm-adapter-ansible/blob/master/docs/index.md)

2) Ansible packages now have to of type: "openstack" or "aws"

3) Before launching a package, a pop of the same type needs to be registered. I have added in the code a function for registering an OpenStack PoP, by also supplying the auth credentials. 

4) Auth credentials are now taken from the PoP and not the package, so the credentials can/should be removed from the play.

Let me know if you have any questions 